### PR TITLE
Add Rahn heading and theme toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,7 @@ function updateCursor(){
 }
 
 let history = []; let hIndex = -1;
+let lampsMode = false; let lampsPrevTheme = null;
 function print(html){ const line = document.createElement('pre'); line.className='line'; line.innerHTML = html; screenEl.appendChild(line); screenEl.scrollTop = screenEl.scrollHeight; }
 function printPrompt(cmd){ const p = document.createElement('pre'); p.className='line'; p.innerHTML = `<span class="prompt">ronny@home:~$</span> ${cmd}`; screenEl.appendChild(p); }
 function parseArgs(str){ const re = /"([^"]+)"|(\S+)/g; const out=[]; let m; while((m=re.exec(str))) out.push(m[1]||m[2]); return out; }
@@ -155,8 +156,15 @@ document.addEventListener('DOMContentLoaded', ()=>{
   if (lamps){
     lamps.addEventListener('click', (e)=>{
       e.preventDefault();
-      setTheme('amber');
-      print('Diagnostics: amber phosphor engaged.');
+      if (!lampsMode){
+        lampsPrevTheme = loadTheme();
+        setTheme('amber');
+        print('Diagnostics: amber phosphor engaged.');
+      } else {
+        setTheme(lampsPrevTheme || 'green');
+        print('Diagnostics: original phosphor restored.');
+      }
+      lampsMode = !lampsMode;
     });
   }
 });

--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
 </head>
 <body>
   <div id="crt-overlay"></div>
+  <h1 id="page-title">Terminal of Rahn</h1>
+  <section id="about-rahn">
+    <h2>About Rahn</h2>
+    <p>Brief description about Rahn goes here.</p>
+  </section>
   <main id="terminal" aria-label="Retro terminal">
     <header class="banner">
       <div class="brand">RONNY-TERM v2.2</div>

--- a/style.css
+++ b/style.css
@@ -11,8 +11,10 @@
 :root.theme-green{ --fg:#00ff88; --fg-dim:#00c06a; --accent:#00ff00; --shadow:#003b24; }
 :root.theme-phosphor{ --fg:#7CFFA1; --fg-dim:#5ad08a; --accent:#B2FFBA; --shadow:#214d35; }
 *{ box-sizing:border-box } html,body{ height:100% }
-body{ margin:0; background:var(--bg); color:var(--fg); font-family:var(--font); line-height:1.45; text-shadow:0 0 6px var(--shadow); overflow:hidden }
+body{ margin:0; background:var(--bg); color:var(--fg); font-family:var(--font); line-height:1.45; text-shadow:0 0 6px var(--shadow); overflow:auto }
 #crt-overlay{ position:fixed; inset:0; pointer-events:none; background:repeating-linear-gradient(to bottom,transparent 0px,transparent 2px,var(--scanline) 3px,transparent 4px); mix-blend-mode:plus-lighter; opacity:.6 }
+#page-title{ text-align:center; margin:16px 0; font-size:2.5rem; color:var(--fg) }
+#about-rahn{ max-width:600px; margin:0 auto 24px; text-align:center }
 #terminal{ height:100%; display:grid; grid-template-rows:auto 1fr auto; padding:16px; gap:8px }
 .banner{ display:flex; align-items:center; gap:1rem; border-bottom:1px solid var(--fg-dim); padding-bottom:8px; flex-wrap:wrap }
 .brand{ letter-spacing:.1em }


### PR DESCRIPTION
## Summary
- Add top-centered "Terminal of Rahn" title and placeholder About section
- Allow lamps-test button to toggle back to the previous theme
- Style new sections and enable page scrolling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68be7075fd5c833195723922fdbc04da