### PR TITLE
feat: implement basic drag-and-drop todo scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ A single-page, static website that looks and behaves like an old-school terminal
 - 100% static: just open `index.html`
 
 ## How to Use
-1. Open `index.html` in your browser to test locally.
-2. Deploy anywhere static (GitHub Pages, Netlify, Vercel).
+1. Open `index.html` in your browser to test the retro terminal.
+2. Open `todo.html` for a simple drag-and-drop todo scheduler.
+3. Deploy anywhere static (GitHub Pages, Netlify, Vercel).
 
 ### Deploy to GitHub Pages (quick)
 - Create a new GitHub repo, add these files, commit & push.

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       <div class="brand">RONNY-TERM v2.2</div>
       <nav class="quick-links" id="quick-links"></nav>
       <a href="matrix.html" class="btn-link">[ EPIC ]</a>
+      <a href="todo.html" class="btn-link">[ TODO ]</a>
       <a href="#" id="lamps-test" class="btn-link">[ LAMPS TEST ]</a>
       <div class="theme-switch" aria-label="Theme">
         <button class="btn-link small" data-theme="green">[ GREEN ]</button>

--- a/todo.css
+++ b/todo.css
@@ -1,0 +1,88 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background: #f7f7f7;
+}
+
+header {
+  text-align: center;
+}
+
+#add-task {
+  text-align: center;
+  margin: 1rem 0;
+}
+
+#add-task input {
+  width: 60%;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+#lists {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.list {
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  width: 200px;
+}
+
+.list h2 {
+  text-align: center;
+  margin-top: 0;
+}
+
+.list ul {
+  list-style: none;
+  padding: 0;
+  min-height: 150px;
+}
+
+.list li {
+  background: #e0e0e0;
+  margin: 0.25rem 0;
+  padding: 0.25rem;
+  cursor: grab;
+}
+
+#week-view {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+#week-days {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.day {
+  background: #fff;
+  border: 1px solid #ccc;
+  width: 120px;
+  display: flex;
+  flex-direction: column;
+}
+
+.day-header {
+  background: #ddd;
+  text-align: center;
+  padding: 0.25rem;
+  font-weight: bold;
+}
+
+.day ul {
+  flex: 1;
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem;
+  min-height: 100px;
+}

--- a/todo.html
+++ b/todo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Todo Scheduler</title>
+  <link rel="stylesheet" href="todo.css" />
+</head>
+<body>
+  <header>
+    <h1>Todo Scheduler</h1>
+    <p>Type a task and press Enter. Drag tasks to schedule.</p>
+  </header>
+
+  <section id="add-task">
+    <input id="task-input" type="text" placeholder="New task" />
+  </section>
+
+  <section id="lists">
+    <div class="list">
+      <h2>Inbox</h2>
+      <ul id="inbox-list" class="drop-zone"></ul>
+    </div>
+    <div class="list">
+      <h2>Tomorrow</h2>
+      <ul id="tomorrow-list" class="drop-zone"></ul>
+    </div>
+    <div class="list">
+      <h2>Next Week</h2>
+      <ul id="nextweek-list" class="drop-zone"></ul>
+    </div>
+  </section>
+
+  <section id="week-view">
+    <button id="week-prev" aria-label="Previous week">&lt;</button>
+    <div id="week-days"></div>
+    <button id="week-next" aria-label="Next week">&gt;</button>
+  </section>
+
+  <div id="backlog" hidden></div>
+
+  <script src="todo.js"></script>
+</body>
+</html>

--- a/todo.js
+++ b/todo.js
@@ -1,0 +1,140 @@
+// Simple Todo Scheduler with drag and drop
+
+document.addEventListener('DOMContentLoaded', () => {
+  const taskInput = document.getElementById('task-input');
+  const inboxList = document.getElementById('inbox-list');
+  const tomorrowList = document.getElementById('tomorrow-list');
+  const nextWeekList = document.getElementById('nextweek-list');
+  const weekDays = document.getElementById('week-days');
+  const weekPrev = document.getElementById('week-prev');
+  const weekNext = document.getElementById('week-next');
+  const backlog = document.getElementById('backlog');
+
+  let currentWeekStart = startOfWeek(new Date());
+  let taskCounter = 0;
+  const tasks = {};
+
+  taskInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && taskInput.value.trim()) {
+      const id = `task-${taskCounter++}`;
+      const li = document.createElement('li');
+      li.textContent = taskInput.value.trim();
+      li.className = 'task';
+      li.id = id;
+      li.draggable = true;
+      li.dataset.list = 'inbox-list';
+      li.addEventListener('dragstart', dragStart);
+      tasks[id] = li;
+      taskInput.value = '';
+      renderTasks();
+    }
+  });
+
+  function dragStart(e) {
+    e.dataTransfer.setData('text/plain', e.target.id);
+  }
+
+  function setupDropZone(zone) {
+    zone.addEventListener('dragover', (e) => e.preventDefault());
+    zone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      const id = e.dataTransfer.getData('text/plain');
+      const task = tasks[id];
+      if (!task) return;
+      if (zone.dataset.date) {
+        task.dataset.date = zone.dataset.date;
+        delete task.dataset.list;
+      } else {
+        task.dataset.list = zone.id;
+        delete task.dataset.date;
+      }
+      renderTasks();
+    });
+  }
+
+  function startOfWeek(date) {
+    const d = new Date(date);
+    const day = d.getDay();
+    const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+    d.setDate(diff);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
+
+  function formatISO(date) {
+    return date.toISOString().split('T')[0];
+  }
+
+  function renderWeek() {
+    weekDays.innerHTML = '';
+    for (let i = 0; i < 7; i++) {
+      const dayDate = new Date(currentWeekStart);
+      dayDate.setDate(currentWeekStart.getDate() + i);
+      const column = document.createElement('div');
+      column.className = 'day';
+      const header = document.createElement('div');
+      header.className = 'day-header';
+      header.textContent = dayDate.toLocaleDateString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+      });
+      const ul = document.createElement('ul');
+      ul.className = 'drop-zone';
+      ul.dataset.date = formatISO(dayDate);
+      column.appendChild(header);
+      column.appendChild(ul);
+      weekDays.appendChild(column);
+      setupDropZone(ul);
+    }
+    renderTasks();
+  }
+
+  weekPrev.addEventListener('click', () => {
+    currentWeekStart.setDate(currentWeekStart.getDate() - 7);
+    renderWeek();
+  });
+
+  weekNext.addEventListener('click', () => {
+    currentWeekStart.setDate(currentWeekStart.getDate() + 7);
+    renderWeek();
+  });
+
+  function renderTasks() {
+    inboxList.innerHTML = '';
+    tomorrowList.innerHTML = '';
+    nextWeekList.innerHTML = '';
+    document.querySelectorAll('#week-days ul').forEach((ul) => (ul.innerHTML = ''));
+    backlog.innerHTML = '';
+
+    Object.values(tasks).forEach((task) => {
+      if (task.dataset.list) {
+        const listZone = document.getElementById(task.dataset.list);
+        if (listZone) listZone.appendChild(task);
+        else backlog.appendChild(task);
+      } else if (task.dataset.date) {
+        const zone = document.querySelector(`#week-days ul[data-date="${task.dataset.date}"]`);
+        if (zone) zone.appendChild(task);
+        else backlog.appendChild(task);
+      } else {
+        inboxList.appendChild(task);
+      }
+    });
+  }
+
+  function setupStaticDates() {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrowList.dataset.date = formatISO(tomorrow);
+
+    const nextWeek = startOfWeek(new Date());
+    nextWeek.setDate(nextWeek.getDate() + 7);
+    nextWeekList.dataset.date = formatISO(nextWeek);
+  }
+
+  // Initialization
+  [inboxList, tomorrowList, nextWeekList].forEach(setupDropZone);
+  setupStaticDates();
+  renderWeek();
+  renderTasks();
+});


### PR DESCRIPTION
## Summary
- add `todo.html` page with Inbox, Tomorrow, Next Week lists and a weekly calendar
- enable drag-and-drop scheduling logic with persistence across weeks
- link new planner from terminal home page and document usage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bc4fe7b483319765c564bfd08e89