### PR TITLE
Add interactive SVG generator page

### DIFF
--- a/svg-generator.css
+++ b/svg-generator.css
@@ -1,0 +1,193 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'JetBrains Mono', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: hsl(222 45% 11% / 1);
+  --panel: hsl(222 45% 16% / 1);
+  --panel-light: hsl(210 38% 96% / 1);
+  --text: hsl(210 35% 96% / 1);
+  --accent: hsl(200 82% 56% / 1);
+  --border: hsl(222 28% 30% / 1);
+  --shadow: 0 20px 40px -20px hsl(222 60% 20% / 0.65);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(120deg, hsl(222 55% 12%), hsl(203 65% 18%));
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 3vw, 3rem);
+  box-sizing: border-box;
+}
+
+.app {
+  width: min(1100px, 100%);
+  background: color-mix(in srgb, var(--panel) 75%, var(--panel-light));
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  padding: clamp(1.5rem, 2vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2vw, 2.25rem);
+}
+
+.app__header h1 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  margin: 0 0 0.25em;
+}
+
+.app__header p {
+  margin: 0;
+  line-height: 1.6;
+  max-width: 70ch;
+  color: color-mix(in srgb, var(--text) 70%, white);
+}
+
+.app__content {
+  display: grid;
+  gap: clamp(1.5rem, 2.5vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  align-content: start;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--panel) 82%, black 18%);
+  border: 1px solid var(--border);
+}
+
+.control,
+.control--full {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--text);
+}
+
+.control--full {
+  grid-column: 1 / -1;
+}
+
+label {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+  color: inherit;
+}
+
+input,
+select,
+textarea {
+  border-radius: 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, white 30%);
+  background: color-mix(in srgb, var(--panel) 55%, black 45%);
+  padding: 0.65rem 0.8rem;
+  box-sizing: border-box;
+}
+
+input[type="color"] {
+  padding: 0.35rem;
+  height: 2.5rem;
+}
+
+input[type="range"] {
+  appearance: none;
+  height: 0.35rem;
+  background: color-mix(in srgb, var(--panel) 25%, white 25%);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid color-mix(in srgb, var(--border) 35%, white 65%);
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid color-mix(in srgb, var(--border) 35%, white 65%);
+}
+
+output {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.button {
+  grid-column: 1 / -1;
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  background: var(--accent);
+  color: hsl(210 35% 96%);
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px -15px var(--accent);
+}
+
+.preview {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.preview__frame {
+  aspect-ratio: 1;
+  width: min(100%, 360px);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--panel) 50%, black 40%);
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+}
+
+.preview svg {
+  width: 100%;
+  height: 100%;
+}
+
+.preview__code {
+  min-height: 140px;
+  resize: vertical;
+  background: color-mix(in srgb, var(--panel) 50%, black 50%);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  color: color-mix(in srgb, var(--text) 90%, white);
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem;
+  }
+
+  .controls {
+    grid-template-columns: 1fr;
+  }
+}

--- a/svg-generator.html
+++ b/svg-generator.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SVG Shape Generator</title>
+  <link rel="stylesheet" href="svg-generator.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <main class="app">
+    <header class="app__header">
+      <h1>SVG Shape Generator</h1>
+      <p>Create simple SVG shapes with intuitive sliders, preview them instantly, and download the artwork.</p>
+    </header>
+
+    <section class="app__content">
+      <form class="controls" id="shape-form">
+        <div class="control control--full">
+          <label for="shape-select">Shape</label>
+          <select id="shape-select" name="shape">
+            <option value="rect">Rectangle</option>
+            <option value="circle">Circle</option>
+            <option value="ellipse">Ellipse</option>
+            <option value="polygon">Polygon</option>
+          </select>
+        </div>
+
+        <fieldset class="control-group" id="dimension-controls" aria-label="Shape dimensions"></fieldset>
+
+        <div class="control">
+          <label for="fill-color">Fill</label>
+          <input type="color" id="fill-color" name="fill" value="#3182ce" />
+        </div>
+
+        <div class="control">
+          <label for="stroke-color">Stroke</label>
+          <input type="color" id="stroke-color" name="stroke" value="#1a202c" />
+        </div>
+
+        <div class="control">
+          <label for="stroke-width">Stroke Width</label>
+          <input type="range" id="stroke-width" name="strokeWidth" min="0" max="20" value="2" />
+          <output for="stroke-width" id="stroke-width-output">2</output>
+        </div>
+
+        <button type="button" class="button" id="download-btn">Download SVG</button>
+      </form>
+
+      <section class="preview" aria-label="SVG preview">
+        <div class="preview__frame">
+          <svg id="preview-svg" xmlns="http://www.w3.org/2000/svg" role="img" viewBox="0 0 300 300">
+            <title>Generated shape preview</title>
+          </svg>
+        </div>
+        <textarea class="preview__code" id="svg-code" readonly aria-label="SVG code"></textarea>
+      </section>
+    </section>
+  </main>
+
+  <script src="svg-generator.js"></script>
+</body>
+</html>

--- a/svg-generator.js
+++ b/svg-generator.js
@@ -1,0 +1,167 @@
+const dimensionContainer = document.getElementById('dimension-controls');
+const shapeSelect = document.getElementById('shape-select');
+const fillInput = document.getElementById('fill-color');
+const strokeInput = document.getElementById('stroke-color');
+const strokeWidthInput = document.getElementById('stroke-width');
+const strokeWidthOutput = document.getElementById('stroke-width-output');
+const svg = document.getElementById('preview-svg');
+const svgCode = document.getElementById('svg-code');
+const downloadBtn = document.getElementById('download-btn');
+
+const shapeConfigs = {
+  rect: [
+    { id: 'width', label: 'Width', min: 10, max: 300, value: 200 },
+    { id: 'height', label: 'Height', min: 10, max: 300, value: 150 },
+    { id: 'x', label: 'X Position', min: 0, max: 300, value: 50 },
+    { id: 'y', label: 'Y Position', min: 0, max: 300, value: 75 },
+    { id: 'rx', label: 'Corner Radius', min: 0, max: 80, value: 12 }
+  ],
+  circle: [
+    { id: 'r', label: 'Radius', min: 10, max: 150, value: 80 },
+    { id: 'cx', label: 'Center X', min: 0, max: 300, value: 150 },
+    { id: 'cy', label: 'Center Y', min: 0, max: 300, value: 150 }
+  ],
+  ellipse: [
+    { id: 'rx', label: 'Radius X', min: 10, max: 150, value: 110 },
+    { id: 'ry', label: 'Radius Y', min: 10, max: 150, value: 70 },
+    { id: 'cx', label: 'Center X', min: 0, max: 300, value: 150 },
+    { id: 'cy', label: 'Center Y', min: 0, max: 300, value: 150 }
+  ],
+  polygon: [
+    { id: 'sides', label: 'Sides', min: 3, max: 10, value: 6, step: 1 },
+    { id: 'radius', label: 'Radius', min: 20, max: 150, value: 110 },
+    { id: 'rotation', label: 'Rotation', min: 0, max: 360, value: 0 }
+  ]
+};
+
+const formState = new Map();
+
+function createControl({ id, label, min, max, value, step = 1 }) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'control';
+  wrapper.dataset.id = id;
+
+  const controlLabel = document.createElement('label');
+  controlLabel.setAttribute('for', `control-${id}`);
+  controlLabel.textContent = label;
+
+  const input = document.createElement('input');
+  input.type = 'range';
+  input.id = `control-${id}`;
+  input.name = id;
+  input.min = min;
+  input.max = max;
+  input.value = value;
+  input.step = step;
+
+  const output = document.createElement('output');
+  output.htmlFor = input.id;
+  output.textContent = value;
+
+  input.addEventListener('input', () => {
+    output.textContent = input.value;
+    formState.set(id, Number(input.value));
+    renderSvg();
+  });
+
+  wrapper.append(controlLabel, input, output);
+  return wrapper;
+}
+
+function buildDimensionControls(shape) {
+  dimensionContainer.innerHTML = '';
+  formState.clear();
+  const config = shapeConfigs[shape];
+  config.forEach((cfg) => {
+    const control = createControl(cfg);
+    dimensionContainer.appendChild(control);
+    formState.set(cfg.id, Number(cfg.value));
+  });
+}
+
+function polygonPoints(cx, cy, radius, sides, rotation = 0) {
+  const angle = (Math.PI * 2) / sides;
+  const rotationRad = (rotation * Math.PI) / 180;
+  const points = [];
+  for (let i = 0; i < sides; i++) {
+    const currentAngle = i * angle + rotationRad - Math.PI / 2;
+    const x = cx + radius * Math.cos(currentAngle);
+    const y = cy + radius * Math.sin(currentAngle);
+    points.push(`${x.toFixed(2)},${y.toFixed(2)}`);
+  }
+  return points.join(' ');
+}
+
+function renderSvg() {
+  const shape = shapeSelect.value;
+  const fill = fillInput.value;
+  const stroke = strokeInput.value;
+  const strokeWidth = Number(strokeWidthInput.value);
+
+  let shapeElement = '';
+  const values = Object.fromEntries(formState);
+
+  if (shape === 'rect') {
+    const { width, height, x, y, rx } = values;
+    shapeElement = `<rect x="${x}" y="${y}" width="${width}" height="${height}" rx="${rx}" />`;
+  } else if (shape === 'circle') {
+    const { r, cx, cy } = values;
+    shapeElement = `<circle cx="${cx}" cy="${cy}" r="${r}" />`;
+  } else if (shape === 'ellipse') {
+    const { rx, ry, cx, cy } = values;
+    shapeElement = `<ellipse cx="${cx}" cy="${cy}" rx="${rx}" ry="${ry}" />`;
+  } else if (shape === 'polygon') {
+    const { sides, radius, rotation } = values;
+    const cx = 150;
+    const cy = 150;
+    const points = polygonPoints(cx, cy, radius, sides, rotation);
+    shapeElement = `<polygon points="${points}" />`;
+  }
+
+  const svgMarkup = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300">
+  <g fill="${fill}" stroke="${stroke}" stroke-width="${strokeWidth}" stroke-linejoin="round">
+    ${shapeElement}
+  </g>
+</svg>`;
+
+  svg.innerHTML = `
+    <g fill="${fill}" stroke="${stroke}" stroke-width="${strokeWidth}" stroke-linejoin="round">
+      ${shapeElement}
+    </g>`;
+
+  svgCode.value = svgMarkup;
+}
+
+function handleStrokeWidthChange() {
+  strokeWidthOutput.textContent = strokeWidthInput.value;
+  renderSvg();
+}
+
+function init() {
+  buildDimensionControls(shapeSelect.value);
+  strokeWidthOutput.textContent = strokeWidthInput.value;
+  renderSvg();
+}
+
+shapeSelect.addEventListener('change', () => {
+  buildDimensionControls(shapeSelect.value);
+  renderSvg();
+});
+
+fillInput.addEventListener('input', renderSvg);
+strokeInput.addEventListener('input', renderSvg);
+strokeWidthInput.addEventListener('input', handleStrokeWidthChange);
+
+downloadBtn.addEventListener('click', () => {
+  const blob = new Blob([svgCode.value], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'generated-shape.svg';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+});
+
+init();


### PR DESCRIPTION
## Summary
- add a standalone SVG generator page with controls for shape, color, and stroke
- style the interface with a responsive, panel-based layout and modern typography
- implement JavaScript to render shape previews, show SVG markup, and enable downloads

## Testing
- Manual testing in browser

------
https://chatgpt.com/codex/tasks/task_e_68e066161268833185bcf30db95efe4a