### PR TITLE
Add modern SVG generator UI with live preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ A single-page, static website that looks and behaves like an old-school terminal
 
 ## How to Use
 1. Open `index.html` in your browser to test the retro terminal.
-2. Open `todo.html` for a simple drag-and-drop todo scheduler.
-3. Deploy anywhere static (GitHub Pages, Netlify, Vercel).
+2. Open `svg.html` for a modern SVG playground with live preview and export tools.
+3. Open `todo.html` for a simple drag-and-drop todo scheduler.
+4. Deploy anywhere static (GitHub Pages, Netlify, Vercel).
 
 ### Deploy to GitHub Pages (quick)
 - Create a new GitHub repo, add these files, commit & push.
@@ -23,6 +24,7 @@ A single-page, static website that looks and behaves like an old-school terminal
 ## Customize
 - Edit text, links, or commands in `app.js` (look for the `commands` object).
 - Update colors and effects in `style.css`.
+- Try the SVG generator UI in `svg.html` with styles in `svg.css` and behaviors in `svg.js`.
 
 
 ---

--- a/svg.css
+++ b/svg.css
@@ -1,0 +1,429 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --bg-soft: rgba(15, 23, 42, 0.65);
+  --bg-panel: rgba(15, 23, 42, 0.72);
+  --bg-panel-light: rgba(255, 255, 255, 0.04);
+  --accent: #6366f1;
+  --accent-strong: #4338ca;
+  --surface: rgba(255, 255, 255, 0.08);
+  --border: rgba(148, 163, 184, 0.24);
+  --border-strong: rgba(148, 163, 184, 0.42);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --shadow: 0 25px 45px rgba(15, 23, 42, 0.35);
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --transition: 200ms ease;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(120% 120% at 50% 0%, #1e293b 0%, #0f172a 60%, #020617 100%);
+  color: var(--text);
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  padding: clamp(24px, 4vw, 48px);
+}
+
+.app-shell {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(20px, 4vw, 36px);
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  background: linear-gradient(145deg, rgba(99, 102, 241, 0.15), rgba(14, 165, 233, 0.1));
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  padding: clamp(20px, 3vw, 28px);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.app-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(96, 165, 250, 0.25), transparent 45%),
+    radial-gradient(circle at bottom left, rgba(244, 114, 182, 0.2), transparent 40%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.6;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.logo {
+  height: 54px;
+  width: 54px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 30% 30%, rgba(96, 165, 250, 0.85), rgba(79, 70, 229, 0.65));
+  color: #f8fafc;
+  font-size: 24px;
+  font-weight: 700;
+  box-shadow: inset 0 1px 6px rgba(255, 255, 255, 0.35), 0 10px 24px rgba(99, 102, 241, 0.45);
+}
+
+.brand-copy h1 {
+  margin: 0;
+  font-size: clamp(1.85rem, 2.6vw, 2.4rem);
+  font-weight: 700;
+}
+
+.brand-copy p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  max-width: 32ch;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  position: relative;
+  z-index: 1;
+}
+
+.link {
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.35);
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  transition: transform var(--transition), border var(--transition), background var(--transition);
+  backdrop-filter: blur(14px);
+}
+
+.link:hover,
+.link:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(96, 165, 250, 0.6);
+  background: rgba(96, 165, 250, 0.15);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(20px, 3vw, 32px);
+}
+
+.panel {
+  background: var(--bg-panel);
+  border-radius: var(--radius-md);
+  padding: clamp(20px, 3vw, 28px);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.field-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.95rem;
+}
+
+.field span {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.field input,
+.field select,
+.shape-fields textarea {
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  padding: 10px 12px;
+  font: inherit;
+  background: rgba(15, 23, 42, 0.55);
+  color: inherit;
+  transition: border var(--transition), background var(--transition), box-shadow var(--transition);
+}
+
+.field input:focus-visible,
+.field select:focus-visible,
+.shape-fields textarea:focus-visible {
+  border-color: rgba(99, 102, 241, 0.7);
+  outline: none;
+  background: rgba(15, 23, 42, 0.7);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+}
+
+.shape-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.shape-fields {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.shape-fields .field {
+  gap: 4px;
+}
+
+.primary,
+.ghost {
+  cursor: pointer;
+  font: inherit;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 10px 18px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform var(--transition), background var(--transition), border var(--transition), color var(--transition);
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #f8fafc;
+  box-shadow: 0 12px 25px rgba(99, 102, 241, 0.35);
+}
+
+.primary:hover,
+.primary:focus-visible {
+  transform: translateY(-2px);
+}
+
+.ghost {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.2);
+  color: inherit;
+}
+
+.ghost:hover,
+.ghost:focus-visible {
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.ghost.destructive:hover,
+.ghost.destructive:focus-visible {
+  border-color: rgba(248, 113, 113, 0.55);
+  color: #fca5a5;
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.shape-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.shape-empty {
+  text-align: center;
+  color: var(--muted);
+  padding: 18px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px dashed rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.4);
+  font-size: 0.92rem;
+}
+
+.shape-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel-light);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.shape-summary {
+  font-size: 0.95rem;
+}
+
+.shape-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.panel-preview {
+  grid-column: span 2;
+}
+
+.preview-wrap {
+  min-height: 340px;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.35);
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+}
+
+.preview-wrap svg {
+  max-width: 100%;
+  max-height: 100%;
+  filter: drop-shadow(0 20px 30px rgba(15, 23, 42, 0.55));
+}
+
+.preview-wrap::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.6;
+  background-size: 40px 40px;
+  pointer-events: none;
+}
+
+.preview-wrap[data-grid="dots"]::before {
+  background-image: radial-gradient(circle, rgba(148, 163, 184, 0.2) 1px, transparent 1px);
+}
+
+.preview-wrap[data-grid="lines"]::before {
+  background-image: linear-gradient(rgba(148, 163, 184, 0.16) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.16) 1px, transparent 1px);
+}
+
+.code-block {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.code-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+#code-output {
+  min-height: 160px;
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+  font-size: 0.85rem;
+  resize: vertical;
+  background: rgba(2, 6, 23, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: var(--text);
+}
+
+.dialog {
+  border: none;
+  background: rgba(2, 6, 23, 0.9);
+  color: inherit;
+  padding: 0;
+  border-radius: var(--radius-md);
+  min-width: min(420px, 90vw);
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.dialog header,
+.dialog-footer {
+  padding: 18px 22px;
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.dialog-body {
+  padding: 20px 22px 24px;
+  display: grid;
+  gap: 12px;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+#toast {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  background: rgba(15, 23, 42, 0.88);
+  border-radius: 14px;
+  padding: 14px 18px;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 180ms ease, transform 180ms ease;
+  pointer-events: none;
+}
+
+#toast.active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 960px) {
+  .panel-preview {
+    grid-column: span 1;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 18px;
+  }
+
+  .app-header {
+    border-radius: var(--radius-md);
+  }
+
+  .panel {
+    border-radius: var(--radius-sm);
+  }
+}

--- a/svg.html
+++ b/svg.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SVG Playground</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="svg.css" />
+</head>
+<body>
+  <div class="app-shell">
+    <header class="app-header">
+      <div class="brand">
+        <span class="logo" aria-hidden="true">◆</span>
+        <div class="brand-copy">
+          <h1>SVG Playground</h1>
+          <p>Craft scalable vector graphics visually and export clean markup.</p>
+        </div>
+      </div>
+      <div class="header-actions">
+        <a class="link" href="index.html">Retro Terminal</a>
+        <a class="link" href="matrix.html">Matrix Rain</a>
+        <a class="link" href="todo.html">Task Board</a>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="panel">
+        <h2>Canvas</h2>
+        <div class="field-grid">
+          <label class="field">
+            <span>Width</span>
+            <input id="canvas-width" type="number" min="1" step="1" value="600" />
+          </label>
+          <label class="field">
+            <span>Height</span>
+            <input id="canvas-height" type="number" min="1" step="1" value="400" />
+          </label>
+          <label class="field">
+            <span>Background</span>
+            <input id="canvas-background" type="color" value="#0f172a" />
+          </label>
+          <label class="field">
+            <span>Grid</span>
+            <select id="canvas-grid">
+              <option value="none">None</option>
+              <option value="dots">Dots</option>
+              <option value="lines">Lines</option>
+            </select>
+          </label>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Add Shape</h2>
+          <button id="clear-shapes" type="button" class="ghost">Clear All</button>
+        </div>
+        <form id="shape-form" class="shape-form">
+          <label class="field">
+            <span>Type</span>
+            <select id="shape-type">
+              <option value="rectangle">Rectangle</option>
+              <option value="circle">Circle</option>
+              <option value="ellipse">Ellipse</option>
+              <option value="line">Line</option>
+              <option value="polygon">Polygon</option>
+              <option value="text">Text</option>
+            </select>
+          </label>
+          <div id="shape-fields" class="shape-fields"></div>
+          <button type="submit" class="primary">Add to Canvas</button>
+        </form>
+        <div id="shape-list" class="shape-list" aria-live="polite"></div>
+      </section>
+
+      <section class="panel panel-preview">
+        <div class="panel-head">
+          <h2>Preview</h2>
+          <button id="download-svg" type="button" class="ghost">Download SVG</button>
+        </div>
+        <div id="preview-wrap" class="preview-wrap" aria-live="polite"></div>
+        <div class="code-block">
+          <div class="code-head">
+            <span>SVG Markup</span>
+            <button id="copy-code" type="button" class="ghost">Copy</button>
+          </div>
+          <textarea id="code-output" readonly spellcheck="false"></textarea>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <template id="shape-row-template">
+    <div class="shape-row">
+      <div class="shape-summary"></div>
+      <div class="shape-actions">
+        <button data-action="edit" type="button" class="ghost">Edit</button>
+        <button data-action="delete" type="button" class="ghost destructive">Delete</button>
+      </div>
+    </div>
+  </template>
+
+  <dialog id="edit-dialog">
+    <form method="dialog" class="dialog">
+      <header>
+        <h3>Edit Shape</h3>
+      </header>
+      <div class="dialog-body">
+        <div id="edit-fields" class="shape-fields"></div>
+      </div>
+      <footer class="dialog-footer">
+        <button value="cancel" class="ghost">Cancel</button>
+        <button value="confirm" class="primary">Save changes</button>
+      </footer>
+    </form>
+  </dialog>
+
+  <div id="toast" role="status" aria-live="polite"></div>
+  <script src="svg.js" type="module"></script>
+</body>
+</html>

--- a/svg.js
+++ b/svg.js
@@ -1,0 +1,482 @@
+const canvasWidthInput = document.getElementById('canvas-width');
+const canvasHeightInput = document.getElementById('canvas-height');
+const canvasBackgroundInput = document.getElementById('canvas-background');
+const canvasGridSelect = document.getElementById('canvas-grid');
+const shapeForm = document.getElementById('shape-form');
+const shapeTypeSelect = document.getElementById('shape-type');
+const shapeFieldsContainer = document.getElementById('shape-fields');
+const shapeList = document.getElementById('shape-list');
+const previewWrap = document.getElementById('preview-wrap');
+const codeOutput = document.getElementById('code-output');
+const clearShapesBtn = document.getElementById('clear-shapes');
+const copyCodeBtn = document.getElementById('copy-code');
+const downloadBtn = document.getElementById('download-svg');
+const toast = document.getElementById('toast');
+const editDialog = document.getElementById('edit-dialog');
+const editFieldsContainer = document.getElementById('edit-fields');
+const templateRow = document.getElementById('shape-row-template');
+const parser = new DOMParser();
+
+const state = {
+  width: 600,
+  height: 400,
+  background: '#0f172a',
+  grid: 'none',
+  shapes: [],
+};
+
+const SHAPE_DEFS = {
+  rectangle: {
+    label: 'Rectangle',
+    summary: ({ x, y, width, height }) => `Rect • x${x}, y${y}, ${width}×${height}`,
+    fields: [
+      { name: 'x', label: 'X', type: 'number', min: 0, value: 32 },
+      { name: 'y', label: 'Y', type: 'number', min: 0, value: 32 },
+      { name: 'width', label: 'Width', type: 'number', min: 1, value: 160 },
+      { name: 'height', label: 'Height', type: 'number', min: 1, value: 120 },
+      { name: 'rx', label: 'Radius X', type: 'number', min: 0, value: 12 },
+      { name: 'ry', label: 'Radius Y', type: 'number', min: 0, value: 12 },
+      { name: 'fill', label: 'Fill', type: 'color', value: '#6366f1' },
+      { name: 'stroke', label: 'Stroke', type: 'color', value: '#1e293b' },
+      { name: 'strokeWidth', label: 'Stroke W', type: 'number', min: 0, step: 0.5, value: 2 },
+    ],
+  },
+  circle: {
+    label: 'Circle',
+    summary: ({ cx, cy, r }) => `Circle • c${cx},${cy} r${r}`,
+    fields: [
+      { name: 'cx', label: 'Center X', type: 'number', min: 0, value: 220 },
+      { name: 'cy', label: 'Center Y', type: 'number', min: 0, value: 140 },
+      { name: 'r', label: 'Radius', type: 'number', min: 1, value: 70 },
+      { name: 'fill', label: 'Fill', type: 'color', value: '#f472b6' },
+      { name: 'stroke', label: 'Stroke', type: 'color', value: '#0f172a' },
+      { name: 'strokeWidth', label: 'Stroke W', type: 'number', min: 0, step: 0.5, value: 8 },
+      { name: 'opacity', label: 'Opacity', type: 'number', min: 0, max: 1, step: 0.1, value: 0.85 },
+    ],
+  },
+  ellipse: {
+    label: 'Ellipse',
+    summary: ({ cx, cy, rx, ry }) => `Ellipse • c${cx},${cy} rx${rx} ry${ry}`,
+    fields: [
+      { name: 'cx', label: 'Center X', type: 'number', value: 320 },
+      { name: 'cy', label: 'Center Y', type: 'number', value: 180 },
+      { name: 'rx', label: 'Radius X', type: 'number', value: 140 },
+      { name: 'ry', label: 'Radius Y', type: 'number', value: 60 },
+      { name: 'fill', label: 'Fill', type: 'color', value: '#22d3ee' },
+      { name: 'opacity', label: 'Opacity', type: 'number', min: 0, max: 1, step: 0.1, value: 0.6 },
+    ],
+  },
+  line: {
+    label: 'Line',
+    summary: ({ x1, y1, x2, y2 }) => `Line • (${x1},${y1}) → (${x2},${y2})`,
+    fields: [
+      { name: 'x1', label: 'X1', type: 'number', value: 80 },
+      { name: 'y1', label: 'Y1', type: 'number', value: 80 },
+      { name: 'x2', label: 'X2', type: 'number', value: 340 },
+      { name: 'y2', label: 'Y2', type: 'number', value: 220 },
+      { name: 'stroke', label: 'Stroke', type: 'color', value: '#38bdf8' },
+      { name: 'strokeWidth', label: 'Stroke W', type: 'number', min: 0, value: 6 },
+      { name: 'strokeLinecap', label: 'Line Cap', type: 'select', value: 'round', options: ['round', 'butt', 'square'] },
+      { name: 'strokeDasharray', label: 'Dasharray', type: 'text', placeholder: 'e.g. 12 6' },
+    ],
+  },
+  polygon: {
+    label: 'Polygon',
+    summary: ({ points }) => `Polygon • ${points}`,
+    fields: [
+      {
+        name: 'points',
+        label: 'Points',
+        type: 'textarea',
+        placeholder: '40,160 120,40 220,160',
+        rows: 2,
+        value: '80,280 180,160 320,240 400,120',
+      },
+      { name: 'fill', label: 'Fill', type: 'color', value: '#22c55e' },
+      { name: 'stroke', label: 'Stroke', type: 'color', value: '#052e16' },
+      { name: 'strokeWidth', label: 'Stroke W', type: 'number', min: 0, value: 4 },
+      { name: 'opacity', label: 'Opacity', type: 'number', min: 0, max: 1, step: 0.1, value: 0.7 },
+    ],
+  },
+  text: {
+    label: 'Text',
+    summary: ({ content, x, y }) => `Text • "${content}" @ ${x},${y}`,
+    fields: [
+      { name: 'content', label: 'Content', type: 'text', value: 'SVG' },
+      { name: 'x', label: 'X', type: 'number', value: 120 },
+      { name: 'y', label: 'Y', type: 'number', value: 260 },
+      { name: 'fontSize', label: 'Font size', type: 'number', value: 64 },
+      { name: 'fontFamily', label: 'Font family', type: 'text', value: '"Inter", sans-serif' },
+      { name: 'fill', label: 'Fill', type: 'color', value: '#f8fafc' },
+      { name: 'fontWeight', label: 'Weight', type: 'select', value: '700', options: ['400', '500', '600', '700', '800'] },
+      { name: 'letterSpacing', label: 'Letter spacing', type: 'text', placeholder: 'e.g. 4px' },
+    ],
+  },
+};
+
+function createField(def, prefix = '') {
+  const wrapper = document.createElement('label');
+  wrapper.className = 'field';
+  const span = document.createElement('span');
+  span.textContent = def.label;
+  wrapper.appendChild(span);
+
+  let input;
+  if (def.type === 'select') {
+    input = document.createElement('select');
+    def.options.forEach((opt) => {
+      const option = document.createElement('option');
+      option.value = opt;
+      option.textContent = opt;
+      input.appendChild(option);
+    });
+    input.value = def.value ?? '';
+  } else if (def.type === 'textarea') {
+    input = document.createElement('textarea');
+    input.rows = def.rows || 3;
+    if (def.placeholder) input.placeholder = def.placeholder;
+    input.value = def.value ?? '';
+  } else {
+    input = document.createElement('input');
+    input.type = def.type || 'text';
+    if (def.placeholder) input.placeholder = def.placeholder;
+    if (typeof def.min !== 'undefined') input.min = def.min;
+    if (typeof def.max !== 'undefined') input.max = def.max;
+    if (typeof def.step !== 'undefined') input.step = def.step;
+    input.value = def.value ?? '';
+  }
+
+  input.name = prefix + def.name;
+  wrapper.appendChild(input);
+  return wrapper;
+}
+
+function renderShapeFields(target, type, values = {}) {
+  const def = SHAPE_DEFS[type];
+  target.innerHTML = '';
+  if (!def) return;
+  def.fields.forEach((field) => {
+    const fieldEl = createField(field);
+    const input = fieldEl.querySelector('input, select, textarea');
+    if (values[field.name] != null) {
+      input.value = values[field.name];
+    }
+    target.appendChild(fieldEl);
+  });
+}
+
+function formValues(container) {
+  const data = {};
+  container.querySelectorAll('input, select, textarea').forEach((input) => {
+    if (input.type === 'number') {
+      const value = input.value.trim();
+      data[input.name] = value === '' ? '' : Number(value);
+    } else {
+      data[input.name] = input.value;
+    }
+  });
+  return data;
+}
+
+function sanitizeShape(type, values) {
+  const def = SHAPE_DEFS[type];
+  if (!def) return null;
+  const sanitized = { type };
+  def.fields.forEach((field) => {
+    let value = values[field.name];
+    if (value === '' || value == null) return;
+    if (field.type === 'number') {
+      value = Number(value);
+      if (Number.isNaN(value)) return;
+    }
+    sanitized[field.name] = value;
+  });
+  return sanitized;
+}
+
+function shapeToMarkup(shape) {
+  if (!shape) return '';
+  const { type, ...attrs } = shape;
+  switch (type) {
+    case 'rectangle': {
+      const { x = 0, y = 0, width = 100, height = 100, rx, ry, fill, stroke, strokeWidth } = attrs;
+      return `<rect x="${x}" y="${y}" width="${width}" height="${height}"${attr('rx', rx)}${attr('ry', ry)}${attr(
+        'fill',
+        fill
+      )}${attr('stroke', stroke)}${attr('stroke-width', strokeWidth)} />`;
+    }
+    case 'circle': {
+      const { cx = 0, cy = 0, r = 50, fill, stroke, strokeWidth, opacity } = attrs;
+      return `<circle cx="${cx}" cy="${cy}" r="${r}"${attr('fill', fill)}${attr('stroke', stroke)}${attr(
+        'stroke-width',
+        strokeWidth
+      )}${attr('opacity', opacity)} />`;
+    }
+    case 'ellipse': {
+      const { cx = 0, cy = 0, rx = 50, ry = 50, fill, opacity } = attrs;
+      return `<ellipse cx="${cx}" cy="${cy}" rx="${rx}" ry="${ry}"${attr('fill', fill)}${attr('opacity', opacity)} />`;
+    }
+    case 'line': {
+      const { x1 = 0, y1 = 0, x2 = 100, y2 = 100, stroke, strokeWidth, strokeLinecap, strokeDasharray } = attrs;
+      return `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}"${attr('stroke', stroke)}${attr(
+        'stroke-width',
+        strokeWidth
+      )}${attr('stroke-linecap', strokeLinecap)}${attr('stroke-dasharray', strokeDasharray)} />`;
+    }
+    case 'polygon': {
+      const { points = '', fill, stroke, strokeWidth, opacity } = attrs;
+      return `<polygon points="${points}"${attr('fill', fill)}${attr('stroke', stroke)}${attr('stroke-width', strokeWidth)}${attr(
+        'opacity',
+        opacity
+      )} />`;
+    }
+    case 'text': {
+      const { content = '', x = 0, y = 0, fontSize, fontFamily, fill, fontWeight, letterSpacing } = attrs;
+      return `<text x="${x}" y="${y}"${attr('font-size', fontSize)}${attr('font-family', fontFamily)}${attr(
+        'fill',
+        fill
+      )}${attr('font-weight', fontWeight)}${attr('letter-spacing', letterSpacing)}>${escapeHtml(content)}</text>`;
+    }
+    default:
+      return '';
+  }
+}
+
+function attr(name, value) {
+  if (value == null || value === '') return '';
+  return ` ${name}="${value}"`;
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function buildSvgMarkup() {
+  const { width, height, background, shapes } = state;
+  const viewBox = `0 0 ${width} ${height}`;
+  const shapeMarkup = shapes.map((shape) => shapeToMarkup(shape)).join('\n  ');
+  const backgroundRect = `<rect width="100%" height="100%" fill="${background}" />`;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="${viewBox}" role="img">\n  ${backgroundRect}${shapeMarkup ? `\n  ${shapeMarkup}` : ''}\n</svg>`;
+}
+
+function render() {
+  const markup = buildSvgMarkup();
+  codeOutput.value = markup;
+
+  const doc = parser.parseFromString(markup, 'image/svg+xml');
+  const svgEl = doc.querySelector('svg');
+  previewWrap.innerHTML = '';
+  if (svgEl) {
+    const adopted = document.importNode(svgEl, true);
+    previewWrap.appendChild(adopted);
+  } else {
+    const error = document.createElement('p');
+    error.textContent = 'Could not render SVG markup.';
+    previewWrap.appendChild(error);
+  }
+
+  previewWrap.dataset.grid = state.grid;
+  renderShapeList();
+}
+
+function renderShapeList() {
+  shapeList.innerHTML = '';
+  state.shapes.forEach((shape, index) => {
+    const clone = templateRow.content.firstElementChild.cloneNode(true);
+    clone.dataset.index = index.toString();
+    const summary = clone.querySelector('.shape-summary');
+    const def = SHAPE_DEFS[shape.type];
+    if (def && def.summary) {
+      summary.textContent = def.summary(shape);
+    } else {
+      summary.textContent = `${shape.type} shape`;
+    }
+    shapeList.appendChild(clone);
+  });
+
+  if (state.shapes.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'shape-empty';
+    empty.textContent = 'No shapes yet. Use the form above to add one.';
+    shapeList.appendChild(empty);
+  }
+}
+
+function addShape(type, values) {
+  const sanitized = sanitizeShape(type, values);
+  if (!sanitized) return;
+  state.shapes.push(sanitized);
+  render();
+}
+
+function updateShape(index, type, values) {
+  const sanitized = sanitizeShape(type, values);
+  if (!sanitized) return;
+  state.shapes[index] = sanitized;
+  render();
+}
+
+function deleteShape(index) {
+  state.shapes.splice(index, 1);
+  render();
+}
+
+function openEditDialog(index) {
+  const shape = state.shapes[index];
+  if (!shape) return;
+  renderShapeFields(editFieldsContainer, shape.type, shape);
+  editDialog.returnValue = 'cancel';
+  editDialog.showModal();
+  editDialog.addEventListener(
+    'close',
+    () => {
+      if (editDialog.returnValue === 'confirm') {
+        const values = formValues(editFieldsContainer);
+        updateShape(index, shape.type, values);
+        toastMessage('Shape updated');
+      }
+      editFieldsContainer.innerHTML = '';
+    },
+    { once: true }
+  );
+}
+
+function toastMessage(message) {
+  toast.textContent = message;
+  toast.classList.add('active');
+  setTimeout(() => toast.classList.remove('active'), 2200);
+}
+
+function downloadSvg() {
+  const blob = new Blob([codeOutput.value], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'artwork.svg';
+  document.body.appendChild(a);
+  a.click();
+  requestAnimationFrame(() => {
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  });
+  toastMessage('SVG downloaded');
+}
+
+function copyCode() {
+  navigator.clipboard
+    .writeText(codeOutput.value)
+    .then(() => toastMessage('Code copied to clipboard'))
+    .catch(() => toastMessage('Copy failed: clipboard not available'));
+}
+
+canvasWidthInput.addEventListener('input', () => {
+  state.width = Number(canvasWidthInput.value) || state.width;
+  render();
+});
+
+canvasHeightInput.addEventListener('input', () => {
+  state.height = Number(canvasHeightInput.value) || state.height;
+  render();
+});
+
+canvasBackgroundInput.addEventListener('input', () => {
+  state.background = canvasBackgroundInput.value || state.background;
+  render();
+});
+
+canvasGridSelect.addEventListener('change', () => {
+  state.grid = canvasGridSelect.value;
+  render();
+});
+
+shapeTypeSelect.addEventListener('change', () => {
+  renderShapeFields(shapeFieldsContainer, shapeTypeSelect.value);
+});
+
+shapeForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const values = formValues(shapeFieldsContainer);
+  addShape(shapeTypeSelect.value, values);
+  toastMessage(`${SHAPE_DEFS[shapeTypeSelect.value].label} added`);
+});
+
+shapeList.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const row = target.closest('.shape-row');
+  if (!row) return;
+  const index = Number(row.dataset.index);
+  const action = target.dataset.action;
+  if (action === 'delete') {
+    deleteShape(index);
+    toastMessage('Shape removed');
+  }
+  if (action === 'edit') {
+    openEditDialog(index);
+  }
+});
+
+clearShapesBtn.addEventListener('click', () => {
+  state.shapes = [];
+  render();
+  toastMessage('Canvas cleared');
+});
+
+copyCodeBtn.addEventListener('click', copyCode);
+downloadBtn.addEventListener('click', downloadSvg);
+
+renderShapeFields(shapeFieldsContainer, shapeTypeSelect.value);
+// Seed with a pleasant composition so the preview is never empty.
+[
+  {
+    type: 'rectangle',
+    data: {
+      x: 64,
+      y: 48,
+      width: 240,
+      height: 220,
+      rx: 24,
+      ry: 24,
+      fill: '#1f2937',
+      stroke: '#6366f1',
+      strokeWidth: 6,
+    },
+  },
+  {
+    type: 'circle',
+    data: {
+      cx: 340,
+      cy: 150,
+      r: 88,
+      fill: '#6366f1',
+      stroke: '#312e81',
+      strokeWidth: 12,
+      opacity: 0.92,
+    },
+  },
+  {
+    type: 'text',
+    data: {
+      content: 'Vector vibes',
+      x: 80,
+      y: 320,
+      fontSize: 48,
+      fontFamily: '"Inter", sans-serif',
+      fill: '#e0f2fe',
+      fontWeight: '600',
+      letterSpacing: '4px',
+    },
+  },
+].forEach(({ type, data }) => {
+  const shape = sanitizeShape(type, data);
+  if (shape) {
+    state.shapes.push(shape);
+  }
+});
+
+render();


### PR DESCRIPTION
## Summary
- add a new SVG Playground page with modern glassmorphism-inspired layout and navigation links
- implement interactive canvas controls, shape builder, editing dialog, and live preview rendering with export tools
- document the new page in the README alongside existing demos

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e162fab92483319f02d2789d36e61a